### PR TITLE
Verkooporders, artikelen en artikelomzetgroepen

### DIFF
--- a/SnelStart.B2B.Client/B2BClient.cs
+++ b/SnelStart.B2B.Client/B2BClient.cs
@@ -1,14 +1,14 @@
-﻿using System;
+﻿using SnelStart.B2B.Client.Operations;
+using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using SnelStart.B2B.Client.Operations;
 
 namespace SnelStart.B2B.Client
 {
     public class B2BClient : IB2BClient
     {
-        private readonly ClientState _clientState;
+        readonly ClientState _clientState;
 
         public string AccessToken => _clientState.AccessToken;
 
@@ -28,6 +28,9 @@ namespace SnelStart.B2B.Client
         public IRelatieInkoopboekingenOperations RelatieInkoopboekingen { get; }
         public IInkoopBoekingBijlagesOperations InkoopboekingBijlages { get; }
         public IRelatieBijlagesOperations RelatieBijlages { get; }
+        public IArtikelomzetgroepenOperations Artikelomzetgroepen { get; }
+        public IArtikelenOperations Artikelen { get; }
+        public IVerkoopordersOperations Verkooporders { get; }
 
         public B2BClient(Config config)
         {
@@ -56,9 +59,12 @@ namespace SnelStart.B2B.Client
             RelatieInkoopboekingen = new RelatieInkoopboekingenOperations(_clientState);
             InkoopboekingBijlages = new InkoopBoekingBijlagesOperations(_clientState);
             RelatieBijlages = new RelatieBijlagesOperations(_clientState);
+            Artikelomzetgroepen = new ArtikelomzetgroepenOperations(_clientState);
+            Artikelen = new ArtikelenOperations(_clientState);
+            Verkooporders = new VerkoopordersOperations(_clientState);
         }
 
-        private static void ConfigureServicePointManager(Config config)
+        static void ConfigureServicePointManager(Config config)
         {
             ServicePointManager.FindServicePoint(config.AuthUri).ConnectionLeaseTimeout = config.ConnectionLeaseTimeoutInMilliseconds;
             ServicePointManager.FindServicePoint(config.ApiBaseUriVersioned).ConnectionLeaseTimeout = config.ConnectionLeaseTimeoutInMilliseconds;
@@ -71,7 +77,7 @@ namespace SnelStart.B2B.Client
 
         public void Dispose()
         {
-            
+
         }
 
         public async Task AuthorizeAsync()

--- a/SnelStart.B2B.Client/Operations/Artikelen/ArtikelIdentifierModel.cs
+++ b/SnelStart.B2B.Client/Operations/Artikelen/ArtikelIdentifierModel.cs
@@ -1,0 +1,24 @@
+﻿namespace SnelStart.B2B.Client.Operations
+{
+    /// <summary>
+    /// De gegevenscontainer voor een relatie.
+    /// </summary>
+    public class ArtikelIdentifierModel : IdentifierModel
+    {
+        /// <summary>
+        /// Geeft de naam van deze gegevenscontainer terug.
+        /// </summary>
+        public const string ResourceName = "artikelen";
+
+        /// <summary>
+        /// Geeft een instantie van een <see cref="ArtikelModel"/> terug.
+        /// </summary>
+        public ArtikelIdentifierModel() : base(ResourceName)
+        {
+        }
+
+        internal ArtikelIdentifierModel(string resourceName) : base(resourceName)
+        {
+        }
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Artikelen/ArtikelModel.cs
+++ b/SnelStart.B2B.Client/Operations/Artikelen/ArtikelModel.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    public class ArtikelModel : IdentifierModel
+    {
+        /// <summary>
+        /// Geeft de naam van deze gegevenscontainer terug.
+        /// </summary>
+        public const string ResourceName = "artikelen";
+
+        /// <summary>
+        /// Geeft een instantie van een <see cref="ArtikelModel"/> terug.
+        /// </summary>
+        public ArtikelModel() : base(ResourceName)
+        {
+        }
+
+        /// <summary>
+        /// Datum waarop de gegevens van dit artikel zijn aangepast
+        /// </summary>
+        public DateTime ModifiedOn { get; set; }
+
+        public string Artikelcode { get; set; }
+
+        public string Omschrijving { get; set; }
+
+        public ArtikelomzetgroepIdentifierModel ArtikelOmzetgroep { get; set; }
+
+        public double? Verkoopprijs { get; set; }
+
+        public bool IsNonactief { get; }
+
+        public bool Voorraadcontrole { get; set; }
+
+        public double TechnischeVoorraad { get; }
+
+        public double VrijeVoorraad { get; }
+
+
+
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Artikelen/ArtikelomzetgroepenOperations.cs
+++ b/SnelStart.B2B.Client/Operations/Artikelen/ArtikelomzetgroepenOperations.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    class ArtikelomzetgroepenOperations : CrudOperationsBase<ArtikelomzetgroepModel>, IArtikelomzetgroepenOperations
+    {
+        public ArtikelomzetgroepenOperations(ClientState clientState)
+            : base(clientState, ArtikelomzetgroepModel.ResourceName)
+        { }
+
+        public Task<Response<ArtikelomzetgroepModel[]>> GetAllAsync() => GetAllAsync(CancellationToken.None);
+        public Task<Response<ArtikelomzetgroepModel[]>> GetAllAsync(CancellationToken cancellationToken) => ClientState.ExecuteGetAllAsync<ArtikelomzetgroepModel>(ResourceName, cancellationToken);
+
+        public Task<Response<ArtikelomzetgroepModel[]>> GetAsync(string queryString) => GetAsync(queryString, CancellationToken.None);
+        public Task<Response<ArtikelomzetgroepModel[]>> GetAsync(string queryString, CancellationToken cancellationToken) => ClientState.ExecuteGetAsync<ArtikelomzetgroepModel>(ResourceName, queryString, cancellationToken);
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Artikelen/IArtikelenOperations.cs
+++ b/SnelStart.B2B.Client/Operations/Artikelen/IArtikelenOperations.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    public interface IArtikelenOperations : ICrudOperations<ArtikelModel>, IGetAllOperations<ArtikelModel>, IQueryOperations<ArtikelModel>
+    {
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Artikelomzetgroepen/ArtikelenOperations.cs
+++ b/SnelStart.B2B.Client/Operations/Artikelomzetgroepen/ArtikelenOperations.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    class ArtikelenOperations : CrudOperationsBase<ArtikelModel>, IArtikelenOperations
+    {
+        public ArtikelenOperations(ClientState clientState)
+            : base(clientState, ArtikelModel.ResourceName)
+        { }
+
+        public Task<Response<ArtikelModel[]>> GetAllAsync() => GetAllAsync(CancellationToken.None);
+        public Task<Response<ArtikelModel[]>> GetAllAsync(CancellationToken cancellationToken) => ClientState.ExecuteGetAllAsync<ArtikelModel>(ResourceName, cancellationToken);
+
+        public Task<Response<ArtikelModel[]>> GetAsync(string queryString) => GetAsync(queryString, CancellationToken.None);
+        public Task<Response<ArtikelModel[]>> GetAsync(string queryString, CancellationToken cancellationToken) => ClientState.ExecuteGetAsync<ArtikelModel>(ResourceName, queryString, cancellationToken);
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Artikelomzetgroepen/ArtikelomzetgroepIdentifierModel.cs
+++ b/SnelStart.B2B.Client/Operations/Artikelomzetgroepen/ArtikelomzetgroepIdentifierModel.cs
@@ -1,0 +1,24 @@
+﻿namespace SnelStart.B2B.Client.Operations
+{
+    /// <summary>
+    /// De gegevenscontainer voor een relatie.
+    /// </summary>
+    public class ArtikelomzetgroepIdentifierModel : IdentifierModel
+    {
+        /// <summary>
+        /// Geeft de naam van deze gegevenscontainer terug.
+        /// </summary>
+        public const string ResourceName = "artikelomzetgroepen";
+
+        /// <summary>
+        /// Geeft een instantie van een <see cref="ArtikelomzetgroepModel"/> terug.
+        /// </summary>
+        public ArtikelomzetgroepIdentifierModel() : base(ResourceName)
+        {
+        }
+
+        internal ArtikelomzetgroepIdentifierModel(string resourceName) : base(resourceName)
+        {
+        }
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Artikelomzetgroepen/ArtikelomzetgroepModel.cs
+++ b/SnelStart.B2B.Client/Operations/Artikelomzetgroepen/ArtikelomzetgroepModel.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    public class ArtikelomzetgroepModel : IdentifierModel
+    {
+        /// <summary>
+        /// Geeft de naam van deze gegevenscontainer terug.
+        /// </summary>
+        public const string ResourceName = "artikelomzetgroepen";
+
+        /// <summary>
+        /// Geeft een instantie van een <see cref="ArtikelomzetgroepModel"/> terug.
+        /// </summary>
+        public ArtikelomzetgroepModel() : base(ResourceName)
+        {
+        }
+
+        public int Nummer { get; set; }
+
+        public string Omschrijving { get; set; }
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Artikelomzetgroepen/IArtikelomzetgroepenOperations.cs
+++ b/SnelStart.B2B.Client/Operations/Artikelomzetgroepen/IArtikelomzetgroepenOperations.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    public interface IArtikelomzetgroepenOperations : ICrudOperations<ArtikelomzetgroepModel>, IGetAllOperations<ArtikelomzetgroepModel>, IQueryOperations<ArtikelomzetgroepModel>
+    {
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Verkooporders/IVerkoopordersOperations.cs
+++ b/SnelStart.B2B.Client/Operations/Verkooporders/IVerkoopordersOperations.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    public interface IVerkoopordersOperations : ICrudOperations<VerkooporderModel>, IGetAllOperations<VerkooporderModel>, IQueryOperations<VerkooporderModel>
+    {
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Verkooporders/VerkooporderBtwIngaveModel.cs
+++ b/SnelStart.B2B.Client/Operations/Verkooporders/VerkooporderBtwIngaveModel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    /// <summary>
+    /// Een enumeratie van btw-ingave-soorten voor verkooporders.
+    /// </summary>
+    public enum VerkooporderBtwIngaveModel
+    {
+        /// <summary>
+        /// Inclusief
+        /// </summary>
+        Inclusief,
+        /// <summary>
+        /// Exclusief
+        /// </summary>
+        Exclusief,
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Verkooporders/VerkooporderModel.cs
+++ b/SnelStart.B2B.Client/Operations/Verkooporders/VerkooporderModel.cs
@@ -1,0 +1,108 @@
+﻿using System;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    /// <summary>
+    /// De gegevenscontainer voor een verkooporder.
+    /// </summary>
+    public class VerkooporderModel : IdentifierModel
+    {
+        /// <summary>
+        /// Geeft de naam van deze gegevenscontainer terug.
+        /// </summary>
+        public const string ResourceName = "verkooporders";
+
+        /// <summary>
+        /// Geeft een instantie van een <see cref="VerkooporderModel"/> terug.
+        /// </summary>
+        public VerkooporderModel() : base(ResourceName)
+        {
+        }
+
+        /// <summary>
+        /// De relatie ({SnelStart.B2B.Api.V1.Models.IdentifierModel}) waarop de verkooporder wordt aangemaakt.
+        /// </summary>
+        public RelatieIdentifierModel Relatie { get; set; }
+
+        /// <summary>
+        /// Het soort aanmaning ({SnelStart.B2B.Api.V1.Models.Verkooporders.ProcesStatusModel}) dat van toepassing is op de verkooporder (optioneel).
+        /// Indien niet ingegeven, dan is het Order (concept)
+        /// </summary>
+        public ProcesStatusModel? ProcesStatus { get; set; } = ProcesStatusModel.Order;
+
+        /// <summary>
+        /// Het ordernummer
+        /// </summary>
+        public int? Nummer { get; set; }
+
+        /// <summary>
+        /// Datum waarop de gegevens van deze order zijn aangepast
+        /// </summary>
+        public DateTime? ModifiedOn { get; set; }
+
+        /// <summary>
+        /// De orderdatum
+        /// </summary>
+        public DateTime Datum { get; set; }
+
+        /// <summary>
+        /// De krediettermijn (in dagen) van de verkooporder. \r\n<remarks>Indien dit veld leeg is dan wordt het krediettermijn van de klant gebruikt.
+        /// Waarde moet tussen 0 en 100 liggen.
+        /// </summary>
+        public int? Krediettermijn { get; set; }
+
+        /// <summary>
+        /// De omschrijving van de order
+        /// </summary>
+        public string Omschrijving { get; set; }
+
+        /// <summary>
+        /// Het betalingskenmerk van de order
+        /// </summary>
+        public string Betalingskenmerk { get; set; }
+
+        /// <summary>
+        /// De incassomachtiging voor deze order
+        /// </summary>
+        public IncassoMachtigingIdentifierModel Incassomachtiging { get; set; }
+
+        /// <summary>
+        /// Het aflever-/verzendadres voor deze order
+        /// </summary>
+        public AdresModel Afleveradres { get; set; }
+
+        /// <summary>
+        /// Het factuuradres voor deze order
+        /// </summary>
+        public AdresModel FactuurAdres { get; set; }
+
+        /// <summary>
+        /// Btw-ingavesoort voor deze order.
+        /// Indien niet opgegeven, wordt Exclusief gehanteerd.
+        /// </summary>
+        public VerkooporderBtwIngaveModel? VerkooporderBtwIngaveModel { get; set; } = Operations.VerkooporderBtwIngaveModel.Exclusief;
+
+        /// <summary>
+        /// Kostenplaats
+        /// </summary>
+        public KostenplaatsIdentifierModel Kostenplaats { get; set; }
+
+        public VerkooporderRegelModel[] Regels { get; set; } = new VerkooporderRegelModel[0];
+
+        /// <summary>
+        /// Ordermemo
+        /// </summary>
+        public string Memo { get; set; }
+
+        /// <summary>
+        /// Factuurkorting in procenten
+        /// </summary>
+        public double? Factuurkorting { get; set; }
+
+        /// <summary>
+        /// De verkoopfactuur die bij deze order hoort
+        /// </summary>
+        public VerkoopFactuurModel Verkoopfactuur { get; set; }
+
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Verkooporders/VerkooporderProcesStatusModel.cs
+++ b/SnelStart.B2B.Client/Operations/Verkooporders/VerkooporderProcesStatusModel.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    /// <summary>
+    /// Een enumeratie van Proces-statussen voor verkooporders.
+    /// </summary>
+    public enum ProcesStatusModel
+    {
+        /// <summary>
+        /// Order
+        /// </summary>
+        Order,
+        /// <summary>
+        /// Offerte
+        /// </summary>
+        Offerte,
+        /// <summary>
+        /// Bevestiging
+        /// </summary>
+        Bevestiging,
+        /// <summary>
+        /// Werkbon
+        /// </summary>
+        Werkbon,
+        /// <summary>
+        /// Pakbon
+        /// </summary>
+        Pakbon,
+        /// <summary>
+        /// Afhaalbon
+        /// </summary>
+        Afhaalbon,
+        /// <summary>
+        /// Contantbon
+        /// </summary>
+        Contantbon,
+        /// <summary>
+        /// Factuur
+        /// </summary>
+        Factuur
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Verkooporders/VerkooporderRegelModel.cs
+++ b/SnelStart.B2B.Client/Operations/Verkooporders/VerkooporderRegelModel.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    public class VerkooporderRegelModel
+    {
+        public ArtikelIdentifierModel Artikel { get; set; }
+
+        /// <summary>
+        /// Omschrijving van de orderregel. Indien deze leeg is wordt de omschrijving van het artikel in dit veld gezet.
+        /// </summary>
+        public string Omschrijving { get; set; }
+
+        public double Stuksprijs { get; set; }
+
+        public double Aantal { get; set; } 
+
+        public double KortingsPercentage { get; set; }
+
+        public double Totaal { get; set; } 
+    }
+}

--- a/SnelStart.B2B.Client/Operations/Verkooporders/VerkoopordersOperations.cs
+++ b/SnelStart.B2B.Client/Operations/Verkooporders/VerkoopordersOperations.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SnelStart.B2B.Client.Operations
+{
+    class VerkoopordersOperations : CrudOperationsBase<VerkooporderModel>, IVerkoopordersOperations
+    {
+        public VerkoopordersOperations(ClientState clientState)
+            : base(clientState, VerkooporderModel.ResourceName)
+        { }
+
+        public Task<Response<VerkooporderModel[]>> GetAllAsync() => GetAllAsync(CancellationToken.None);
+        public Task<Response<VerkooporderModel[]>> GetAllAsync(CancellationToken cancellationToken) => ClientState.ExecuteGetAllAsync<VerkooporderModel>(ResourceName, cancellationToken);
+
+        public Task<Response<VerkooporderModel[]>> GetAsync(string queryString) => GetAsync(queryString, CancellationToken.None);
+        public Task<Response<VerkooporderModel[]>> GetAsync(string queryString, CancellationToken cancellationToken) => ClientState.ExecuteGetAsync<VerkooporderModel>(ResourceName, queryString, cancellationToken);
+    }
+}


### PR DESCRIPTION
Toegevoegd: Verkooporders met gerelateerde objecten (regels, artikelen, artikelomzetgroepen)

Opmerking: bij het aanmaken van een verkooporder met datum (alleen datum), wordt deze in SnelStart Web correct weergegeven, maar in SnelStart 12 als de dag ervoor om 22.00u. Lijkt erop dat ergens een (onnodige?) Utc-conversie wordt gedaan.