### PR TITLE
fix: BtwBoekingSoortModel can be nullable

### DIFF
--- a/SnelStart.B2B.Client/Operations/Inkoopboekingen/BtwBoekingModel.cs
+++ b/SnelStart.B2B.Client/Operations/Inkoopboekingen/BtwBoekingModel.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// De btw-soort waarop het btw-bedrag wordt geboekt.
         /// </summary>
-        public BtwBoekingSoortModel BtwSoort { get; set; }
+        public BtwBoekingSoortModel? BtwSoort { get; set; }
 
         /// <summary>
         /// Het btw-bedrag dat voor de gegeven btwsoort wordt geboekt.


### PR DESCRIPTION
Wanneer geen btw wordt gebruikt, moet het btwsoort bij de inkoopfactuur worden leeggelaten, (null).

- https://b2bapi-developer.snelstart.nl/docs/services/57bb00f34a3a8710c85ed7dc/operations/v1-inkoopboekingen-post?&pattern=inkoop