### PR TITLE
Really get all results when calling GetAllAsync

### DIFF
--- a/SnelStart.B2B.Client/Operations/Grootboeken/GrootboekenOperations.cs
+++ b/SnelStart.B2B.Client/Operations/Grootboeken/GrootboekenOperations.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SnelStart.B2B.Client.Operations
@@ -10,7 +11,41 @@ namespace SnelStart.B2B.Client.Operations
         { }
 
         public Task<Response<GrootboekModel[]>> GetAllAsync() => GetAllAsync(CancellationToken.None);
-        public Task<Response<GrootboekModel[]>> GetAllAsync(CancellationToken cancellationToken) => ClientState.ExecuteGetAllAsync< GrootboekModel>(ResourceName, cancellationToken);
+        public Task<Response<GrootboekModel[]>> GetAllAsync(CancellationToken cancellationToken)
+        {
+
+            var result = ClientState.ExecuteGetAllAsync<GrootboekModel>(ResourceName, cancellationToken);
+            return result.ContinueWith<Response<GrootboekModel[]>>((firstTaskResult) =>
+            {
+                if (firstTaskResult.Result.Result?.Count() == 500)
+                {
+                    var grootboeken = firstTaskResult.Result.Result;
+                    bool hasNextPage = true;
+                    var skip = 500;
+                    while (hasNextPage)
+                    {
+                        var nextPageResult = GetAsync($"$skip={skip}&$top=500").GetAwaiter().GetResult();
+                        if ((int)nextPageResult.HttpStatusCode >= 200 && (int)nextPageResult.HttpStatusCode <= 299)
+                        {
+                            hasNextPage = nextPageResult.Result.Count() == 500;
+                            skip += nextPageResult.Result.Count();
+                            grootboeken = grootboeken.Concat(nextPageResult.Result).ToArray();
+                        }
+                    }
+
+                    return new Response<GrootboekModel[]>()
+                    {
+                        HttpStatusCode = firstTaskResult.Result.HttpStatusCode,
+                        ResponseBody = firstTaskResult.Result.ResponseBody,
+                        Result = grootboeken
+                    };
+                }
+                else
+                {
+                    return firstTaskResult.Result;
+                }
+            });
+        }
         public Task<Response<GrootboekModel[]>> GetAsync(string queryString) => GetAsync(queryString, CancellationToken.None);
         public Task<Response<GrootboekModel[]>> GetAsync(string queryString, CancellationToken cancellationToken) => ClientState.ExecuteGetAsync<GrootboekModel>(ResourceName, queryString, cancellationToken);
     }


### PR DESCRIPTION
Ran into this issue when using the B2BClient. Because the grootboeken endpoint has OData filtering only the first 500 result are returned. This is very confusing, because the method name is GetAllAsync. 

I tried to get all the result in the pull request, but I'm not sure if this is the correct way to do this.